### PR TITLE
[Fix]作成時category.usersに追加 #9

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -7,6 +7,7 @@ class CategoriesController < ApplicationController
 
   def create
     @category = Category.new(category_params)
+    @category.users << current_user
     if @category.save
       redirect_to category_path(@category)
     else


### PR DESCRIPTION
what
カテゴリーを作成した際に、作成したユーザをcategory.usersに追加させる

why
カテゴリーメンバーに参加する手間を省くため