### PR TITLE
[Fix]sort #4

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,10 +25,7 @@ class PostsController < ApplicationController
 
   def index
     if params[:sort] == "popular"
-      @posts = Post.includes(:bookmarked_users).sort do |a, b|
-        b.bookmarked_users.size <=> a.bookmarked_users.size
-      end
-      @posts = Kaminari.paginate_array(@posts).page(params[:page]).per(12)
+      @posts = Post.left_joins(:bookmarks).group(:id).order("count(bookmarks.post_id) desc").page(params[:page]).per(12)
     else
       @posts = Post.order(created_at: :desc).page(params[:page]).per(12)
     end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -9,12 +9,10 @@ class SearchesController < ApplicationController
         @users = User.page(params[:page]).per(15)
       end
     elsif @range == 'post'
-      tag = Tag.where("name LIKE?", "%#{@word}%")
-      @posts = Post.left_joins(:tag_maps).where(:tag_maps => { :tag_id => tag.ids })
-      @posts = Kaminari.paginate_array(@posts).page(params[:page]).per(12)
+      @posts = Post.left_joins(:tags).where("tags.name LIKE?", "%#{@word}%").order(created_at: :desc).page(params[:page]).per(12).distinct
       if @posts.blank?
         flash[:notice] = "一致するタグがありませんでした"
-        @posts = Post.page(params[:page]).per(12)
+        @posts = Post.order(created_at: :desc).page(params[:page]).per(12)
       end
     else
       @categories = Category.where("name LIKE?", "%#{@word}%").page(params[:page]).per(15)
@@ -23,6 +21,7 @@ class SearchesController < ApplicationController
         @categories = Category.includes(:category_users).sort do |a, b|
           b.category_users.size <=> a.category_users.size
         end
+      else
         @categories = Kaminari.paginate_array(@categories).page(params[:page]).per(12)
       end
     end


### PR DESCRIPTION
what
sortをsqlのorderに変更

why
Rubyのsortを使用すると全てのPostデータを抽出してbookmarkの数を比べてsortするため、Postデータが１万件など多くなった時にパフォーマンスに影響する